### PR TITLE
iterate in a manner compatible with both salt-ssh and salt

### DIFF
--- a/wireguard/init.sls
+++ b/wireguard/init.sls
@@ -1,4 +1,4 @@
-{%- for interface_name, interface_dict in salt.pillar.get('wireguard:interfaces', {}).items() %}
+{%- for interface_name, interface_dict in salt['pillar.get']('wireguard:interfaces', {}).items() %}
 
   {% if interface_dict.get('delete', False) %}
 stop and disable wg-quick@{{interface_name}}:


### PR DESCRIPTION
salt.pillar.get() and salt['pillar.get'] appear to function differently between `salt-ssh` and `salt`, and the existing existing invocation does not appear to render correctly under `salt-ssh` in 2019.2.0.

Edit: Initially misattributed this to the difference between pillar.get() and salt['pillar.get'] within templating context as per saltstack/salt#7566 - but it does not appear to be relevant in this particular case.