### PR TITLE
Allow defaults to be overridden with pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -54,3 +54,11 @@ wireguard:
           [Peer]
           PublicKey = peer
           AllowedIPs = fe80::2
+
+  # Internal formula configuration can be overridden using values placed
+  # in this lookup table. For more variables that can be overridden, see
+  # defaults.yaml and os*map.yaml
+  # lookup:
+  #   packages:
+  #     - wireguard-tools
+  #     - wireguard-kmod

--- a/wireguard/map.jinja
+++ b/wireguard/map.jinja
@@ -13,9 +13,9 @@
     merge=salt['grains.filter_by'](osfamilymap, grain='os_family',
       merge=salt['grains.filter_by'](osmap, grain='os',
         merge=salt['grains.filter_by'](osfingermap, grain='osfinger',
-          merge=salt['grains.filter_by'](salt['grains.filter_by'](osarchmap, grain='osfinger'), grain='osarch')
+          merge=salt['grains.filter_by'](salt['grains.filter_by'](osarchmap, grain='osfinger'), grain='osarch',
+            merge=salt['pillar.get']('wireguard'))
         )
       )
     )
 ) %}
-

--- a/wireguard/map.jinja
+++ b/wireguard/map.jinja
@@ -14,7 +14,7 @@
       merge=salt['grains.filter_by'](osmap, grain='os',
         merge=salt['grains.filter_by'](osfingermap, grain='osfinger',
           merge=salt['grains.filter_by'](salt['grains.filter_by'](osarchmap, grain='osfinger'), grain='osarch',
-            merge=salt['pillar.get']('wireguard'))
+            merge=salt['pillar.get']('wireguard:lookup'))
         )
       )
     )


### PR DESCRIPTION
CentOS doesn't have a wireguard metapackage. With that in mind, I think the package(s) to be installed should be configurable with pillar. In particular, this would allow kmod or dkms packages to be selected explicitly.